### PR TITLE
Default .gdbinit

### DIFF
--- a/rc/.gdbinit
+++ b/rc/.gdbinit
@@ -1,0 +1,1 @@
+source /opt/peda/peda.py


### PR DESCRIPTION
Added a 'default' .gdbinit file, so that peda works
'out-of-the-(pwn)box'.

```
root@exploit-dev:~/gdbinittest# ./run.sh gdbinittest
076217eaa547cb5dbc889c3f4f0cc87dd4d208141b71db4911fcae31f31eb170
                         ______
___________      ___________  /___________  __
___  __ \_ | /| / /_  __ \_  __ \  __ \_  |/_/
__  /_/ /_ |/ |/ /_  / / /  /_/ / /_/ /_>  <
_  .___/____/|__/ /_/ /_//_.___/\____//_/|_|
/_/                           by superkojiman

root@gdbinittest:/#
root@gdbinittest:/# gdb -q
gdb-peda$
```